### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "./GameLogic.py gui"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # AStarSnake
+
+[![Run on Repl.it](https://repl.it/badge/github/durgadarba97/AStarSnake)](https://repl.it/github/durgadarba97/AStarSnake)
+
 This is my first exploration in trying to automate the game snake. 
 In the folders you find the Snake file that's used to house a lot of the main classes, 
 a world file that's used to house the gameplay and game states, and an A* file that's used to 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).